### PR TITLE
Add more link to up to date job boards in the "this is unmaintained" header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 For general job boards for all roles in climate, see [Climatebase](https://climatebase.org/), [Climate People](https://www.climatepeople.com/), [Climate Tech Careers](https://www.climatetechcareers.com/#jobboards) - which is a aggregator of job boards.
 
-For climate job boards specific to software engineers, see [ClimateTechList](https://www.climatetechlist.com/), and the #softwareengineer slack channels within [My Climate Journey](https://www.mcjcollective.com/) and [Work on Climate](https://workonclimate.org/) slack communities.
+For climate job boards specific to software engineers, see [ClimateTechList](https://www.climatetechlist.com/), and the `#a-software-engineer` / `#jobs-software-engineering` channels within [My Climate Journey](https://www.mcjcollective.com/) and [Work on Climate](https://workonclimate.org/) slack communities, respectively.
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Climate jobs for software engineers
 
-***NOTE: This is unmaintained and there are very active job boards now. See [Climatebase](https://climatebase.org/), [Climate People](https://www.climatepeople.com/), etc.***
+***NOTE: This is unmaintained and there are very active job boards now:***
+
+For general job boards for all roles in climate, see [Climatebase](https://climatebase.org/), [Climate People](https://www.climatepeople.com/), [Climate Tech Careers](https://www.climatetechcareers.com/#jobboards) - which is a aggregator of job boards.
+
+For climate job boards specific to software engineers, see [ClimateTechList](https://www.climatetechlist.com/), and the #softwareengineer slack channels within [My Climate Journey](https://www.mcjcollective.com/) and [Work on Climate](https://workonclimate.org/) slack communities.
 
 * * *
 


### PR DESCRIPTION
This repo shows up as #4 for `climate jobs software engineers` so figured I would suggest this update

Disclaimer: I created `climatetechlist.com`, I found this repo from googling `climate jobs software engineers` while I was testing SEO workflows for potential users new to climate (i.e. SWEs who don't know about any climate resources so they Google)